### PR TITLE
Desconsiderado diretorio em analise de cobertura de codigo.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
 ignore:
-  - "*/tests/*”
-  - "*/configs/*"
+  - "tests/**/*”
+  - "configs/**/*"


### PR DESCRIPTION
 - Correção no padrão para excluir diretórios.